### PR TITLE
Fix undefined file variable

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -56,7 +56,9 @@ var Format = cli.Command{
 
 		var out io.Writer
 		if c.String("output") != "" {
-			out, err = os.OpenFile(c.String("output"), os.O_CREATE|os.O_WRONLY, 0644)
+			var file *os.File
+			file, err = os.OpenFile(c.String("output"), os.O_CREATE|os.O_WRONLY, 0644)
+			out = io.Writer(file)
 			if err != nil {
 				return errors.Wrap(err, "unable to open output file")
 			}


### PR DESCRIPTION
This fix solves the following error raised when building signal-back:

`cmd/format.go:64:8: undefined: file`