### PR TITLE
Add support for MMS/attachments.

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/csv"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -137,10 +140,17 @@ func CSV(bf *types.BackupFile, message string, out io.Writer) error {
 // uses. Layout described at their website
 // http://synctech.com.au/fields-in-xml-backup-files/
 func XML(bf *types.BackupFile, out io.Writer) error {
+	type attachmentDetails struct {
+		Size uint64
+		Body string
+	}
+
+	var attachmentBuffer bytes.Buffer
+	attachmentEncoder := base64.NewEncoder(base64.StdEncoding, &attachmentBuffer)
+	attachments := map[uint64]attachmentDetails{}
 	smses := &types.SMSes{}
 	mmses := map[uint64]types.MMS{}
 	mmsParts := map[uint64][]types.MMSPart{}
-	warnedMMS := false
 
 	for {
 		f, err := bf.Frame()
@@ -150,10 +160,16 @@ func XML(bf *types.BackupFile, out io.Writer) error {
 
 		// Attachment needs removing
 		if a := f.GetAttachment(); a != nil {
-			err := bf.DecryptAttachment(a, ioutil.Discard)
+			err := bf.DecryptAttachment(a, attachmentEncoder)
+			attachmentEncoder.Close()
 			if err != nil {
-				return errors.Wrap(err, "unable to chew through attachment")
+				return errors.Wrap(err, "unable to process attachment")
 			}
+			attachments[*a.AttachmentId] = attachmentDetails{
+				Size: uint64(*a.Length),
+				Body: attachmentBuffer.String(),
+			}
+			attachmentBuffer.Reset()
 		}
 
 		if stmt := f.GetStatement(); stmt != nil {
@@ -165,23 +181,58 @@ func XML(bf *types.BackupFile, out io.Writer) error {
 				}
 			}
 
-			if strings.HasPrefix(*stmt.Statement, "INSERT INTO mms") && !warnedMMS {
-				// TODO this
-				log.Println("MMS export not yet supported")
-				warnedMMS = true
+			if strings.HasPrefix(*stmt.Statement, "INSERT INTO mms") {
+				id, mms, err := types.NewMMSFromStatement(stmt)
+				if err == nil {
+					mmses[id] = *mms
+				}
 			}
 
 			if strings.HasPrefix(*stmt.Statement, "INSERT INTO part") {
-				// TODO also this
+				mmsId, part, err := types.NewPartFromStatement(stmt)
+				if err == nil {
+					mmsParts[mmsId] = append(mmsParts[mmsId], *part)
+				}
 			}
 		}
 	}
 
-	for id, p := range mmsParts {
-		if mms, ok := mmses[id]; ok {
-			mms.Parts = p
-			smses.MMS = append(smses.MMS, mms)
+	for id, mms := range mmses {
+		var messageSize uint64
+		parts, ok := mmsParts[id]
+		if ok {
+			for i := 0; i < len(parts); i++ {
+				if attachment, ok := attachments[parts[i].UniqueID]; ok {
+					messageSize += attachment.Size
+					parts[i].Data = &attachment.Body
+				}
+			}
 		}
+		if mms.Body != nil && len(*mms.Body) > 0 {
+			parts = append(parts, types.MMSPart{
+				Seq:   0,
+				Ct:    "text/plain",
+				Name:  "null",
+				ChSet: types.CharsetUTF8,
+				Cd:    "null",
+				Fn:    "null",
+				CID:   "null",
+				Cl:    fmt.Sprintf("txt%06d.txt", id),
+				CttS:  "null",
+				CttT:  "null",
+				Text:  *mms.Body,
+			})
+			messageSize += uint64(len(*mms.Body))
+			if len(parts) == 1 {
+				mms.TextOnly = 1
+			}
+		}
+		if len(parts) == 0 {
+			continue
+		}
+		mms.Parts = parts
+		mms.MSize = &messageSize
+		smses.MMS = append(smses.MMS, mms)
 	}
 
 	smses.Count = len(smses.SMS)

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -232,6 +232,15 @@ func XML(bf *types.BackupFile, out io.Writer) error {
 		}
 		mms.Parts = parts
 		mms.MSize = &messageSize
+		if mms.MType == nil {
+			if types.SetMMSMessageType(types.MMSSendReq, &mms) != nil {
+				panic("logic error: this should never happen")
+			}
+			smses.MMS = append(smses.MMS, mms)
+			if types.SetMMSMessageType(types.MMSRetrieveConf, &mms) != nil {
+				panic("logic error: this should never happen")
+			}
+		}
 		smses.MMS = append(smses.MMS, mms)
 	}
 

--- a/types/raw.go
+++ b/types/raw.go
@@ -206,7 +206,7 @@ func StatementToMMS(sql *signal.SqlStatement) *SQLMMS {
 
 // ParametersToMMS converts a set of SQL parameters to a single MMS.
 func ParametersToMMS(ps []*signal.SqlStatement_SqlParameter) *SQLMMS {
-	if len(ps) != 42 {
+	if len(ps) < 42 {
 		return nil
 	}
 	return &SQLMMS{
@@ -293,7 +293,7 @@ func StatementToPart(sql *signal.SqlStatement) *SQLPart {
 
 // ParametersToPart converts a set of SQL parameters to a single part.
 func ParametersToPart(ps []*signal.SqlStatement_SqlParameter) *SQLPart {
-	if len(ps) != 25 {
+	if len(ps) < 25 {
 		return nil
 	}
 	return &SQLPart{

--- a/types/sms.go
+++ b/types/sms.go
@@ -10,6 +10,12 @@ import (
 	"github.com/xeals/signal-back/signal"
 )
 
+// Character sets as specified by IANA.
+const (
+	CharsetASCII = "3"
+	CharsetUTF8  = "106"
+)
+
 // SMSType is an SMS type as defined by the XML backup spec.
 type SMSType uint64
 
@@ -22,6 +28,31 @@ const (
 	SMSOutbox                  // 4
 	SMSFailed                  // 5
 	SMSQueued                  // 6
+)
+
+// MMS message types as defined by the MMS Encapsulation Protocol.
+// See: http://www.openmobilealliance.org/release/MMS/V1_2-20050429-A/OMA-MMS-ENC-V1_2-20050301-A.pdf
+const (
+	MMSSendReq           uint64 = iota + 128 // 128
+	MMSSendConf                              // 129
+	MMSNotificationInd                       // 130
+	MMSNotifyResponseInd                     // 131
+	MMSRetrieveConf                          // 132
+	MMSAckknowledgeInd                       // 133
+	MMSDeliveryInd                           // 134
+	MMSReadRecInd                            // 135
+	MMSReadOrigInd                           // 136
+	MMSForwardReq                            // 137
+	MMSForwardConf                           // 138
+	MMSMBoxStoreReq                          // 139
+	MMSMBoxStoreConf                         // 140
+	MMSMBoxViewReq                           // 141
+	MMSMBoxViewConf                          // 142
+	MMSMBoxUploadReq                         // 143
+	MMSMBoxUploadConf                        // 144
+	MMSMBoxDeleteReq                         // 145
+	MMSMBoxDeleteConf                        // 146
+	MMSMBoxDescr                             // 147
 )
 
 // SMSes holds a set of MMS or SMS records.
@@ -55,9 +86,10 @@ type SMS struct {
 // MMS represents a Multimedia Messaging Service record.
 type MMS struct {
 	XMLName      xml.Name  `xml:"mms"`
-	Parts        []MMSPart `xml:"parts,attr"`
-	TextOnly     *uint64   `xml:"text_only,attr"`     // optional
-	Sub          *string   `xml:"sub,attr"`           // optional
+	Parts        []MMSPart `xml:"parts"`
+	Body         *string   `xml:"-"`
+	TextOnly     uint64    `xml:"text_only,attr"`     // optional
+	Sub          string    `xml:"sub,attr"`           // optional
 	RetrSt       string    `xml:"retr_st,attr"`       // required
 	Date         uint64    `xml:"date,attr"`          // required
 	CtCls        string    `xml:"ct_cls,attr"`        // required
@@ -67,7 +99,7 @@ type MMS struct {
 	TrID         string    `xml:"tr_id,attr"`         // required
 	St           string    `xml:"st,attr"`            // required
 	MsgBox       uint64    `xml:"msg_box,attr"`       // required
-	Address      uint64    `xml:"address,attr"`       // required
+	Address      string    `xml:"address,attr"`       // required
 	MCls         string    `xml:"m_cls,attr"`         // required
 	DTm          string    `xml:"d_tm,attr"`          // required
 	ReadStatus   string    `xml:"read_status,attr"`   // required
@@ -86,27 +118,28 @@ type MMS struct {
 	RptA         string    `xml:"rpt_a,attr"`         // required
 	Locked       uint64    `xml:"locked,attr"`        // required
 	RetrTxt      string    `xml:"retr_txt,attr"`      // required
-	RespSt       string    `xml:"resp_st,attr"`       // required
-	MSize        string    `xml:"m_size,attr"`        // required
-	ReadableDate *string   `xml:"readable_date,attr"` // optional
+	RespSt       uint64    `xml:"resp_st,attr"`       // required
+	MSize        *uint64   `xml:"m_size,attr"`        // required
+	ReadableDate string    `xml:"readable_date,attr"` // optional
 	ContactName  *string   `xml:"contact_name,attr"`  // optional
 }
 
 // MMSPart holds a data blob for an MMS.
 type MMSPart struct {
-	XMLName xml.Name `xml:"part"`
-	Seq     uint64   `xml:"seq,attr"`   // required
-	Ct      uint64   `xml:"ct,attr"`    // required
-	Name    string   `xml:"name,attr"`  // required
-	ChSet   string   `xml:"chset,attr"` // required
-	Cd      string   `xml:"cd,attr"`    // required
-	Fn      string   `xml:"fn,attr"`    // required
-	CID     string   `xml:"cid,attr"`   // required
-	Cl      string   `xml:"cl,attr"`    // required
-	CttS    string   `xml:"ctt_s,attr"` // required
-	CttT    string   `xml:"ctt_t,attr"` // required
-	Text    string   `xml:"text,attr"`  // required
-	Data    *string  `xml:"data,attr"`  // optional
+	XMLName  xml.Name `xml:"part"`
+	UniqueID uint64   `xml:"-"`
+	Seq      uint64   `xml:"seq,attr"`   // required
+	Ct       string   `xml:"ct,attr"`    // required
+	Name     string   `xml:"name,attr"`  // required
+	ChSet    string   `xml:"chset,attr"` // required
+	Cd       string   `xml:"cd,attr"`    // required
+	Fn       string   `xml:"fn,attr"`    // required
+	CID      string   `xml:"cid,attr"`   // required
+	Cl       string   `xml:"cl,attr"`    // required
+	CttS     string   `xml:"ctt_s,attr"` // required
+	CttT     string   `xml:"ctt_t,attr"` // required
+	Text     string   `xml:"text,attr"`  // required
+	Data     *string  `xml:"data,attr"`  // optional
 }
 
 // NewSMSFromStatement constructs an XML SMS struct from a SQL statement.
@@ -145,15 +178,173 @@ func NewSMSFromStatement(stmt *signal.SqlStatement) (*SMS, error) {
 	return &xml, nil
 }
 
-func NewMMSFromStatement(stmt *signal.SqlStatement) (*MMS, error) {
+func NewMMSFromStatement(stmt *signal.SqlStatement) (uint64, *MMS, error) {
 	mms := StatementToMMS(stmt)
 	if mms == nil {
-		return nil, errors.Errorf("expected 42 columns for MMS, have %v", len(stmt.GetParameters()))
+		return 0, nil, errors.Errorf("expected at least 42 columns for MMS, have %v", len(stmt.GetParameters()))
 	}
 
-	xml := MMS{}
+	xml := MMS{
+		TextOnly:     0,
+		Sub:          "null",
+		RetrSt:       "null",
+		Date:         *mms.DateReceived,
+		CtCls:        "null",
+		SubCs:        "null",
+		Body:         nil,
+		Read:         mms.Read,
+		CtL:          "null",
+		TrID:         "null",
+		St:           "null",
+		MCls:         "personal",
+		DTm:          "null",
+		ReadStatus:   "null",
+		CtT:          "application/vnd.wap.multipart.related",
+		RetrTxtCs:    "null",
+		DateSent:     *mms.DateSent / 1000,
+		Seen:         mms.Read,
+		MType:        *mms.MessageType,
+		Exp:          "null",
+		RespTxt:      "null",
+		RptA:         "null",
+		Locked:       0,
+		RetrTxt:      "null",
+		MSize:        nil,
+		ReadableDate: *intToTime(mms.DateReceived),
+	}
 
-	return &xml, nil
+	switch xml.MType {
+	case MMSSendReq:
+		xml.MsgBox = 2
+		xml.V = 18
+		break
+	case MMSNotificationInd:
+		return 0, nil, errors.Errorf("skipping message with type %v", xml.MType)
+	case MMSRetrieveConf:
+		xml.MsgBox = 1
+		xml.V = 16
+		break
+	default:
+		log.Fatalf("unsupported message type %v encountered on MMS #%d:\nplease report this issue, as well as (if possible) details about the MMS", xml.MType, mms.ID)
+		break
+	}
+
+	if mms.RetrSt != nil {
+		xml.RetrSt = strconv.FormatUint(*mms.RetrSt, 10)
+	}
+	if mms.CtCls != nil {
+		xml.CtCls = strconv.FormatUint(*mms.CtCls, 10)
+	}
+	if mms.SubCs != nil {
+		xml.SubCs = strconv.FormatUint(*mms.SubCs, 10)
+	}
+	if mms.Body != nil {
+		xml.Body = mms.Body
+	}
+	if mms.ContentLocation != nil {
+		xml.CtL = *mms.ContentLocation
+	}
+	if mms.TransactionID != nil {
+		xml.TrID = *mms.TransactionID
+	}
+	if mms.Address != nil {
+		xml.Address = *mms.Address
+	}
+	if mms.Expiry != nil {
+		xml.Exp = strconv.FormatUint(*mms.Expiry, 10)
+	}
+	if mms.MCls != nil {
+		xml.MCls = *mms.MCls
+	}
+	if mms.DTm != nil {
+		xml.DTm = strconv.FormatUint(*mms.DTm, 10)
+	}
+	if mms.ReadStatus != nil {
+		xml.ReadStatus = strconv.FormatUint(*mms.ReadStatus, 10)
+	}
+	if mms.CtT != nil {
+		xml.CtT = *mms.CtT
+	}
+	if mms.RetrTxtCs != nil {
+		xml.RetrTxtCs = strconv.FormatUint(*mms.RetrTxtCs, 10)
+	}
+	if mms.DRpt != nil {
+		xml.DRpt = *mms.DRpt
+	}
+	if mms.MID != nil {
+		xml.MId = *mms.MID
+	}
+	if mms.Pri != nil {
+		xml.Pri = *mms.Pri
+	}
+	if mms.Rr != nil {
+		xml.Rr = *mms.Rr
+	}
+	if mms.RespTxt != nil {
+		xml.RespTxt = *mms.RespTxt
+	}
+	if mms.RptA != nil {
+		xml.RptA = strconv.FormatUint(*mms.RptA, 10)
+	}
+	if mms.RetrTxt != nil {
+		xml.RetrTxt = *mms.RetrTxt
+	}
+	if mms.RespSt != nil {
+		xml.RespSt = *mms.RespSt
+	}
+	if mms.MessageSize != nil {
+		xml.MSize = mms.MessageSize
+	}
+
+	return mms.ID, &xml, nil
+}
+
+func NewPartFromStatement(stmt *signal.SqlStatement) (uint64, *MMSPart, error) {
+	part := StatementToPart(stmt)
+	if part == nil {
+		return 0, nil, errors.Errorf("expected at least 25 columns for part, have %v", len(stmt.GetParameters()))
+	}
+
+	xml := MMSPart{
+		UniqueID: part.UniqueID,
+		Seq:      part.Seq,
+		Ct:       *part.ContentType,
+		Name:     "null",
+		ChSet:    CharsetUTF8,
+		Cd:       "null",
+		Fn:       "null",
+		CID:      "null",
+		Cl:       "null",
+		CttS:     "null",
+		CttT:     "null",
+	}
+
+	if part.Name != nil {
+		xml.Name = *part.Name
+	}
+	if part.Chset != nil {
+		xml.ChSet = strconv.FormatUint(*part.Chset, 10)
+	}
+	if part.ContentDisposition != nil {
+		xml.Cd = *part.ContentDisposition
+	}
+	if part.Fn != nil {
+		xml.Fn = *part.Fn
+	}
+	if part.Cid != nil {
+		xml.CID = *part.Cid
+	}
+	if part.ContentLocation != nil {
+		xml.Cl = *part.ContentLocation
+	}
+	if part.CttS != nil {
+		xml.CttS = strconv.FormatUint(*part.CttS, 10)
+	}
+	if part.CttT != nil {
+		xml.CttT = *part.CttT
+	}
+
+	return *part.MmsID, &xml, nil
 }
 
 func intToTime(n *uint64) *string {


### PR DESCRIPTION
Added support for exporting MMS and their attachments when using the XML
format.  The following has been tested and confirmed working when using
the latest version of SMS Backup and Restore (10.05.210 currently):
- Text-only MMS messages.
- Picture-only MMS messages.
- Text/picture MMS messages.

The following has NOT been tested:
- Non-picture media types.  These should still work, as there is no
  special per-media type handling done.
- Group MMS.  It is unknown to what extent these will work.

Known issues:
- Restoring a backup to Android Messages via SMS Backup and Restore will
  result in MMS that you sent showing "Hidden sender address" in the
  "From" field of the message information.  This happens even when using
  SMS Backup and Restore to back up from and then restore to Android
  Messages however, so there is likely nothing to be done about this.