### PR TITLE
Fix empty XML result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 signal*backup*
 vendor/
-signal-back
+signal-back*
+debug*
 release/
+.vscode/

--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -25,7 +25,7 @@ var Analyse = cli.Command{
 		}
 
 		a, err := AnalyseTables(bf)
-		fmt.Println("This is still largely in flux and reflects whatever task I was having issues with at the time.\n")
+		fmt.Println("This is still largely in flux and reflects whatever task I was having issues with at the time.")
 		fmt.Println(a)
 
 		fmt.Println("part:", len(examples["insert_into_part"].GetParameters()), examples["insert_into_part"])

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -31,12 +31,11 @@ var Extract = cli.Command{
 		}
 
 		if path := c.String("outdir"); path != "" {
-			err := os.MkdirAll(path, 0755)
-			if err != nil {
+			if err = os.MkdirAll(path, 0755); err != nil {
 				return errors.Wrap(err, "unable to create output directory")
 			}
-			err = os.Chdir(path)
-			if err != nil {
+
+			if err = os.Chdir(path); err != nil {
 				return errors.Wrap(err, "unable to change working directory")
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/xeals/signal-back
+
+require (
+	github.com/golang/protobuf v1.1.0
+	github.com/h2non/filetype v1.0.5
+	github.com/pkg/errors v0.8.0
+	github.com/urfave/cli v1.20.0
+	golang.org/x/crypto v0.0.0-20180808211826-de0752318171
+	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
+	gopkg.in/h2non/filetype.v1 v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
+github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/h2non/filetype v1.0.5 h1:Esu2EFM5vrzNynnGQpj0nxhCkzVQh2HRY7AXUh/dyJM=
+github.com/h2non/filetype v1.0.5/go.mod h1:isekKqOuhMj+s/7r3rIeTErIRy4Rub5uBWHfvMusLMU=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
+github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+golang.org/x/crypto v0.0.0-20180808211826-de0752318171 h1:vYogbvSFj2YXcjQxFHu/rASSOt9sLytpCaSkiwQ135I=
+golang.org/x/crypto v0.0.0-20180808211826-de0752318171/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+gopkg.in/h2non/filetype.v1 v1.0.5 h1:CC1jjJjoEhNVbMhXYalmGBhOBK2V70Q1N850wt/98/Y=
+gopkg.in/h2non/filetype.v1 v1.0.5/go.mod h1:M0yem4rwSX5lLVrkEuRRp2/NinFMD5vgJ4DlAhZcfNo=

--- a/types/raw.go
+++ b/types/raw.go
@@ -128,9 +128,16 @@ func StatementToSMS(sql *signal.SqlStatement) *SQLSMS {
 
 // ParametersToSMS converts a set of SQL parameters to a single SMS.
 func ParametersToSMS(ps []*signal.SqlStatement_SqlParameter) *SQLSMS {
-	if len(ps) != 23 {
+	if len(ps) < 22 {
 		return nil
 	}
+
+	// special case for new backup format
+	var unidentified uint64
+	if len(ps) == 23 {
+		unidentified = ps[22].GetIntegerParameter()
+	}
+
 	return &SQLSMS{
 		ID:                   ps[0].GetIntegerParameter(),
 		ThreadID:             ps[1].IntegerParameter,
@@ -154,7 +161,7 @@ func ParametersToSMS(ps []*signal.SqlStatement_SqlParameter) *SQLSMS {
 		ExpireStarted:        ps[19].GetIntegerParameter(),
 		Notified:             ps[20].GetIntegerParameter(),
 		ReadReceiptCount:     ps[21].GetIntegerParameter(),
-		Unidentified:         ps[21].GetIntegerParameter(),
+		Unidentified:         unidentified,
 	}
 }
 
@@ -211,9 +218,16 @@ func StatementToMMS(sql *signal.SqlStatement) *SQLMMS {
 
 // ParametersToMMS converts a set of SQL parameters to a single MMS.
 func ParametersToMMS(ps []*signal.SqlStatement_SqlParameter) *SQLMMS {
-	if len(ps) < 43 {
+	if len(ps) < 42 {
 		return nil
 	}
+
+	// special case for new backup format
+	var unidentified uint64
+	if len(ps) == 43 {
+		unidentified = ps[42].GetIntegerParameter()
+	}
+
 	return &SQLMMS{
 		ID:                   ps[0].GetIntegerParameter(),
 		ThreadID:             ps[1].IntegerParameter,
@@ -257,7 +271,7 @@ func ParametersToMMS(ps []*signal.SqlStatement_SqlParameter) *SQLMMS {
 		ExpireStarted:        ps[39].GetIntegerParameter(),
 		Notified:             ps[40].GetIntegerParameter(),
 		ReadReceiptCount:     ps[41].GetIntegerParameter(),
-		Unidentified:         ps[42].GetIntegerParameter(),
+		Unidentified:         unidentified,
 	}
 }
 

--- a/types/raw.go
+++ b/types/raw.go
@@ -45,6 +45,7 @@ var (
 		"EXPIRE_STARTED",
 		"NOTIFIED",
 		"READ_RECEIPT_COUNT",
+		"UNIDENTIFIED",
 	}
 
 	MMSCSVHeaders = []string{
@@ -90,6 +91,7 @@ var (
 		"EXPIRE_STARTED",
 		"NOTIFIED",
 		"READ_RECEIPT_COUNT",
+		"UNIDENTIFIED",
 	}
 )
 
@@ -116,6 +118,7 @@ type SQLSMS struct {
 	ExpireStarted        uint64 // default 0
 	Notified             uint64 // default 0
 	ReadReceiptCount     uint64 // default 0
+	Unidentified         uint64 // default 0
 }
 
 // StatementToSMS converts a of SQL statement to a single SMS.
@@ -125,7 +128,7 @@ func StatementToSMS(sql *signal.SqlStatement) *SQLSMS {
 
 // ParametersToSMS converts a set of SQL parameters to a single SMS.
 func ParametersToSMS(ps []*signal.SqlStatement_SqlParameter) *SQLSMS {
-	if len(ps) != 22 {
+	if len(ps) != 23 {
 		return nil
 	}
 	return &SQLSMS{
@@ -151,6 +154,7 @@ func ParametersToSMS(ps []*signal.SqlStatement_SqlParameter) *SQLSMS {
 		ExpireStarted:        ps[19].GetIntegerParameter(),
 		Notified:             ps[20].GetIntegerParameter(),
 		ReadReceiptCount:     ps[21].GetIntegerParameter(),
+		Unidentified:         ps[21].GetIntegerParameter(),
 	}
 }
 
@@ -197,6 +201,7 @@ type SQLMMS struct {
 	ExpireStarted        uint64 // default 0
 	Notified             uint64 // default 0
 	ReadReceiptCount     uint64 // default 0
+	Unidentified         uint64 // default 0
 }
 
 // StatementToMMS converts a of SQL statement to a single MMS.
@@ -206,7 +211,7 @@ func StatementToMMS(sql *signal.SqlStatement) *SQLMMS {
 
 // ParametersToMMS converts a set of SQL parameters to a single MMS.
 func ParametersToMMS(ps []*signal.SqlStatement_SqlParameter) *SQLMMS {
-	if len(ps) < 42 {
+	if len(ps) < 43 {
 		return nil
 	}
 	return &SQLMMS{
@@ -252,6 +257,7 @@ func ParametersToMMS(ps []*signal.SqlStatement_SqlParameter) *SQLMMS {
 		ExpireStarted:        ps[39].GetIntegerParameter(),
 		Notified:             ps[40].GetIntegerParameter(),
 		ReadReceiptCount:     ps[41].GetIntegerParameter(),
+		Unidentified:         ps[42].GetIntegerParameter(),
 	}
 }
 


### PR DESCRIPTION
Since some version. Signal backup's SQL statements now include extra field "unidentified", so XML fails to parse SMS insert statements.
This fixes that (and the issue mentioned in https://github.com/xeals/signal-back/issues/38)

This PR consists of:
- fix some linter warnings
- add missing extra SQL field
- add preliminary Go modules support