### PR TITLE
Add Go modules support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/xeals/signal-back
+
+go 1.12
+
+require (
+	github.com/golang/protobuf v1.1.0
+	github.com/h2non/filetype v1.0.5
+	github.com/pkg/errors v0.8.0
+	github.com/urfave/cli v1.20.0
+	golang.org/x/crypto v0.0.0-20180808211826-de0752318171
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
+	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
+	gopkg.in/h2non/filetype.v1 v1.0.5 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/golang/protobuf v1.1.0
 	github.com/h2non/filetype v1.0.5
-	github.com/pkg/errors v0.8.0
+	github.com/pkg/errors v0.8.1
 	github.com/urfave/cli v1.20.0
 	golang.org/x/crypto v0.0.0-20180808211826-de0752318171
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/h2non/filetype v1.0.5
 	github.com/pkg/errors v0.8.1
 	github.com/urfave/cli v1.20.0
+	github.com/xeals/signal-back/signal v0.0.0
 	golang.org/x/crypto v0.0.0-20180808211826-de0752318171
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
 	gopkg.in/h2non/filetype.v1 v1.0.5 // indirect
 )
+
+replace github.com/xeals/signal-back/signal => ./signal

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
+github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/h2non/filetype v1.0.5 h1:Esu2EFM5vrzNynnGQpj0nxhCkzVQh2HRY7AXUh/dyJM=
+github.com/h2non/filetype v1.0.5/go.mod h1:isekKqOuhMj+s/7r3rIeTErIRy4Rub5uBWHfvMusLMU=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
+github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+golang.org/x/crypto v0.0.0-20180808211826-de0752318171 h1:vYogbvSFj2YXcjQxFHu/rASSOt9sLytpCaSkiwQ135I=
+golang.org/x/crypto v0.0.0-20180808211826-de0752318171/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/h2non/filetype.v1 v1.0.5 h1:CC1jjJjoEhNVbMhXYalmGBhOBK2V70Q1N850wt/98/Y=
+gopkg.in/h2non/filetype.v1 v1.0.5/go.mod h1:M0yem4rwSX5lLVrkEuRRp2/NinFMD5vgJ4DlAhZcfNo=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/h2non/filetype v1.0.5 h1:Esu2EFM5vrzNynnGQpj0nxhCkzVQh2HRY7AXUh/dyJM=
 github.com/h2non/filetype v1.0.5/go.mod h1:isekKqOuhMj+s/7r3rIeTErIRy4Rub5uBWHfvMusLMU=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 golang.org/x/crypto v0.0.0-20180808211826-de0752318171 h1:vYogbvSFj2YXcjQxFHu/rASSOt9sLytpCaSkiwQ135I=

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -1,0 +1,8 @@
+module github.com/xeals/signal-back/signal
+
+go 1.12
+
+require (
+	github.com/golang/protobuf v1.1.0
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
+)

--- a/signal/go.sum
+++ b/signal/go.sum
@@ -1,0 +1,4 @@
+github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
+github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
As asked in https://github.com/xeals/signal-back/pull/42 I separated module-related changes from the linter fixes.

Now people will be able to just do `go get github.com/xeals/signal-back` (or add `@latest`, `@v0.2.0`) like the old times (starting with Go 1.12) and get the required binary release with proper dependencies.

By design repo should now also tag the `signal/vX.Y.Z` releases of the `signal` autogenerated submodule, so that other people could use it without dragging the whole binary with it.
This will in turn allow doing `go get github.com/xeals/signal-back/signal` (or with version suffix like with the binary).

If this gets merged, I suggest tagging the merge commit with 2 tags:
- `v0.2.0` for the repo itself
- `signal/v0.1.0` for the submodule